### PR TITLE
Feature (#18) value from other headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,16 @@ providers:
 ```
 
 ## How to dev
+
 ```bash
 $ docker run -d --network host containous/whoami -port 5000
 # traefik --config-file traefik.yml
 ```
+
 ## How to use
 
 To choose a Rule you have to fill the `Type` field with either
+
 - 'Rename'  : to rename a header
 - 'Set'     : to Set a header
 - 'Del'     : to Delete a header
@@ -48,6 +51,7 @@ Each Rule can be named with the `Name` field
 ### Rename
 
 A Rename rule need 2 arguments
+
 - `Header`, the regex of the header you want to replace
 - `Value`, the new header
 
@@ -59,6 +63,7 @@ A Rename rule need 2 arguments
       Value: 'NewHeader'
       Type: 'Rename'
 ```
+
 ```yaml
 # Old header:
 Cache-Control: gzip, deflate
@@ -74,6 +79,7 @@ NewHeader: gzip, deflate
       Value: 'X-Traefik-merged'
       Type: 'Rename'
 ```
+
 ```yaml
 # Old header:
 X-Traefik-uuid: 0
@@ -87,6 +93,7 @@ X-Traefik-merged: 0 # A value from old headers
 A Set rule will either create or replace the header and value (if it already exist)
 
 A rule Set need 2 arguments
+
 - `Header`, the header you want to create
 - `Value`, the value of the new header
 
@@ -98,6 +105,7 @@ A rule Set need 2 arguments
       Value: 'Foo'
       Type: 'Join'
 ```
+
 ```yaml
 # New header:
 Cache-Control: Foo
@@ -106,6 +114,7 @@ Cache-Control: Foo
 ### Delete
 
 A rule Delete need 1 arguments
+
 - `Header`, the header you want to delete
 
 ```yaml
@@ -137,6 +146,7 @@ It needs 3 arguments
         - 'Bar'
       Type: 'Join'
 ```
+
 ```yaml
 # Old header:
 Cache-Control: gzip, deflate
@@ -166,6 +176,7 @@ The rules will be evaluated in the order of definition
   Value: 'False'
   Type: 'Set'
 ```
+
 Will firstly set the header `X-Custom-2` to 'True', then delete it and lastly set it again but with `False`
 
 # Authors

--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ The rules will be evaluated in the order of definition
   Type: 'Set'
 ```
 
+### Advanced: (Re)Using other headers
+
+You can reuse other header values in `Value` or one of the `Values` by setting an additional argument `ValueIsHeaderPrefix`.
+Example:
+
+```yaml
+# Example Usage
+- Rule:
+  Name: 'Header set'
+  Header: 'X-Forwarded-For'
+  Value: '^CF-Connecting-IP'
+  ValueIsHeaderPrefix: "^"
+  Type: 'Set'
+```
+
+```yaml
+# Old header:
+CF-Connecting-IP: 1.1.1.1
+
+# New headers:
+CF-Connecting-IP: 1.1.1.1
+X-Forwarded-For: 1.1.1.1
+```
+
 Will firstly set the header `X-Custom-2` to 'True', then delete it and lastly set it again but with `False`
 
 # Authors

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The rules will be evaluated in the order of definition
 
 ### Advanced: (Re)Using other headers
 
-You can reuse other header values in `Value` or one of the `Values` by setting an additional argument `ValueIsHeaderPrefix`.
+You can reuse other header values in `Value` or one of the `Values` by setting an additional argument `HeaderPrefix`.
 Example:
 
 ```yaml
@@ -188,7 +188,7 @@ Example:
   Name: 'Header set'
   Header: 'X-Forwarded-For'
   Value: '^CF-Connecting-IP'
-  ValueIsHeaderPrefix: "^"
+  HeaderPrefix: "^"
   Type: 'Set'
 ```
 

--- a/htransformation.go
+++ b/htransformation.go
@@ -42,15 +42,15 @@ type HeadersTransformation struct {
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
 	for _, rule := range config.Rules {
 		if rule.Header == "" || rule.Type == "" {
-			return nil, fmt.Errorf("Can't use '%s', some required fields are empty",
+			return nil, fmt.Errorf("can't use '%s', some required fields are empty",
 				rule.Name)
 		}
 		if rule.Type == "Join" && (len(rule.Values) == 0 || rule.Sep == "") {
-			return nil, fmt.Errorf("Can't use '%s', some required fields are empty",
+			return nil, fmt.Errorf("can't use '%s', some required fields are empty",
 				rule.Name)
 		}
 		if rule.ValueIsHeaderPrefix != "" && rule.Value == "" && len(rule.Values) == 0 {
-			return nil, fmt.Errorf("Can't use '%s', cannot set ValueIsHeaderPrefix without passing in Value/Values",
+			return nil, fmt.Errorf("can't use '%s', cannot set ValueIsHeaderPrefix without passing in Value/Values",
 				rule.Name)
 		}
 	}

--- a/htransformation.go
+++ b/htransformation.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 )
 
 // Rule struct so that we get traefik config
 type Rule struct {
-	Name   string   `yaml:"Name"`
-	Header string   `yaml:"Header"`
-	Value  string   `yaml:"Value"`
-	Values []string `yaml:"Values"`
-	Sep    string   `yaml:"Sep"`
-	Type   string   `yaml:"Type"`
+	Name                string   `yaml:"Name"`
+	Header              string   `yaml:"Header"`
+	Value               string   `yaml:"Value"`
+	Values              []string `yaml:"Values"`
+	ValueIsHeaderPrefix string   `yaml:"vauleIsHeaderPrefix"`
+	Sep                 string   `yaml:"Sep"`
+	Type                string   `yaml:"Type"`
 }
 
 // Config holds configuration to be passed to the plugin
@@ -47,6 +49,10 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 			return nil, fmt.Errorf("Can't use '%s', some required fields are empty",
 				rule.Name)
 		}
+		if rule.ValueIsHeaderPrefix != "" && rule.Value == "" && len(rule.Values) == 0 {
+			return nil, fmt.Errorf("Can't use '%s', cannot set ValueIsHeaderPrefix without passing in Value/Values",
+				rule.Name)
+		}
 	}
 	return &HeadersTransformation{
 		rules: config.Rules,
@@ -70,25 +76,40 @@ func (u *HeadersTransformation) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 				if matched {
 					req.Header.Del(headerName)
 					for _, val := range headerValues {
-						req.Header.Set(rule.Value, val)
+						req.Header.Set(getValue(rule.Value, rule.ValueIsHeaderPrefix, req), val)
 					}
 				}
 			}
 		case "Set":
-			req.Header.Set(rule.Header, rule.Value)
+			req.Header.Set(rule.Header, getValue(rule.Value, rule.ValueIsHeaderPrefix, req))
 		case "Del":
 			req.Header.Del(rule.Header)
 		case "Join":
 			if val, ok := req.Header[rule.Header]; ok {
-				req.Header.Del(rule.Header)
 				tmp_val := val[0]
 				for _, value := range rule.Values {
-					tmp_val += rule.Sep + value
+					tmp_val += rule.Sep + getValue(value, rule.ValueIsHeaderPrefix, req)
 				}
+				// Delete after creating the tmp_val, so that if the values refer itself, it won't be empty.
+				req.Header.Del(rule.Header)
 				req.Header.Add(rule.Header, tmp_val)
 			}
 		default:
 		}
 	}
 	u.next.ServeHTTP(rw, req)
+}
+
+// getValue checks if prefix exists, the given prefix is present, and then proceeds to read the existing header (after stripping the prefix) to return as value
+func getValue(ruleValue string, vauleIsHeaderPrefix string, req *http.Request) string {
+	actualValue := ruleValue
+	if vauleIsHeaderPrefix != "" && strings.HasPrefix(ruleValue, vauleIsHeaderPrefix) {
+		header := strings.TrimPrefix(ruleValue, vauleIsHeaderPrefix)
+		// If the resulting value after removing the prefix is empty (value was only prefix), we return the actual value, which is the prefix itself.
+		// This is because doing a req.Header.Get("") would not fly well.
+		if header != "" {
+			actualValue = req.Header.Get(header)
+		}
+	}
+	return actualValue
 }

--- a/htransformation.go
+++ b/htransformation.go
@@ -10,13 +10,13 @@ import (
 
 // Rule struct so that we get traefik config
 type Rule struct {
-	Name                string   `yaml:"Name"`
-	Header              string   `yaml:"Header"`
-	Value               string   `yaml:"Value"`
-	Values              []string `yaml:"Values"`
-	ValueIsHeaderPrefix string   `yaml:"vauleIsHeaderPrefix"`
-	Sep                 string   `yaml:"Sep"`
-	Type                string   `yaml:"Type"`
+	Name         string   `yaml:"Name"`
+	Header       string   `yaml:"Header"`
+	Value        string   `yaml:"Value"`
+	Values       []string `yaml:"Values"`
+	HeaderPrefix string   `yaml:"HeaderPrefix"`
+	Sep          string   `yaml:"Sep"`
+	Type         string   `yaml:"Type"`
 }
 
 // Config holds configuration to be passed to the plugin
@@ -49,8 +49,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 			return nil, fmt.Errorf("can't use '%s', some required fields are empty",
 				rule.Name)
 		}
-		if rule.ValueIsHeaderPrefix != "" && rule.Value == "" && len(rule.Values) == 0 {
-			return nil, fmt.Errorf("can't use '%s', cannot set ValueIsHeaderPrefix without passing in Value/Values",
+		if rule.HeaderPrefix != "" && rule.Value == "" && len(rule.Values) == 0 {
+			return nil, fmt.Errorf("can't use '%s', cannot set HeaderPrefix without passing in Value/Values",
 				rule.Name)
 		}
 	}
@@ -76,19 +76,19 @@ func (u *HeadersTransformation) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 				if matched {
 					req.Header.Del(headerName)
 					for _, val := range headerValues {
-						req.Header.Set(getValue(rule.Value, rule.ValueIsHeaderPrefix, req), val)
+						req.Header.Set(getValue(rule.Value, rule.HeaderPrefix, req), val)
 					}
 				}
 			}
 		case "Set":
-			req.Header.Set(rule.Header, getValue(rule.Value, rule.ValueIsHeaderPrefix, req))
+			req.Header.Set(rule.Header, getValue(rule.Value, rule.HeaderPrefix, req))
 		case "Del":
 			req.Header.Del(rule.Header)
 		case "Join":
 			if val, ok := req.Header[rule.Header]; ok {
 				tmp_val := val[0]
 				for _, value := range rule.Values {
-					tmp_val += rule.Sep + getValue(value, rule.ValueIsHeaderPrefix, req)
+					tmp_val += rule.Sep + getValue(value, rule.HeaderPrefix, req)
 				}
 				// Delete after creating the tmp_val, so that if the values refer itself, it won't be empty.
 				req.Header.Del(rule.Header)

--- a/htransformation_test.go
+++ b/htransformation_test.go
@@ -168,12 +168,12 @@ func TestHeaderRules(t *testing.T) {
 			},
 		},
 		{
-			name: "[Rename] no transformation with ValueIsHeaderPrefix",
+			name: "[Rename] no transformation with HeaderPrefix",
 			rule: plug.Rule{
-				Type:                "Rename",
-				Header:              "not-existing",
-				Value:               "^unused",
-				ValueIsHeaderPrefix: "^",
+				Type:         "Rename",
+				Header:       "not-existing",
+				Value:        "^unused",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo": "Bar",
@@ -185,10 +185,10 @@ func TestHeaderRules(t *testing.T) {
 		{
 			name: "[Rename] one transformation",
 			rule: plug.Rule{
-				Type:                "Rename",
-				Header:              "Test",
-				Value:               "^X-Dest-Header",
-				ValueIsHeaderPrefix: "^",
+				Type:         "Rename",
+				Header:       "Test",
+				Value:        "^X-Dest-Header",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":           "Bar",
@@ -204,10 +204,10 @@ func TestHeaderRules(t *testing.T) {
 		{
 			name: "[Set] new header from existing",
 			rule: plug.Rule{
-				Type:                "Set",
-				Header:              "X-Test",
-				Value:               "^X-Source",
-				ValueIsHeaderPrefix: "^",
+				Type:         "Set",
+				Header:       "X-Test",
+				Value:        "^X-Source",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":      "Bar",
@@ -222,10 +222,10 @@ func TestHeaderRules(t *testing.T) {
 		{
 			name: "[Set] existing header from another existing",
 			rule: plug.Rule{
-				Type:                "Set",
-				Header:              "X-Test",
-				Value:               "^X-Source",
-				ValueIsHeaderPrefix: "^",
+				Type:         "Set",
+				Header:       "X-Test",
+				Value:        "^X-Source",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":      "Bar",
@@ -247,7 +247,7 @@ func TestHeaderRules(t *testing.T) {
 				Values: []string{
 					"^X-Source",
 				},
-				ValueIsHeaderPrefix: "^",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":      "Bar",
@@ -271,7 +271,7 @@ func TestHeaderRules(t *testing.T) {
 					"Compiled",
 					"^X-Source-3",
 				},
-				ValueIsHeaderPrefix: "^",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":        "Bar",
@@ -297,7 +297,7 @@ func TestHeaderRules(t *testing.T) {
 					"^X-Test",
 					"^X-Source-3",
 				},
-				ValueIsHeaderPrefix: "^",
+				HeaderPrefix: "^",
 			},
 			headers: map[string]string{
 				"Foo":        "Bar",

--- a/htransformation_test.go
+++ b/htransformation_test.go
@@ -128,18 +128,19 @@ func TestHeaderRules(t *testing.T) {
 			},
 		},
 		{
-			name: "[Join] Join two headers simple value",
+			name: "[Set] Join headers simple value (same as set)",
 			rule: plug.Rule{
-				Type:   "Join",
+				Type:   "Set",
 				Sep:    ",",
 				Header: "X-Test",
 				Values: []string{
+					"Bar",
 					"Tested",
 				},
 			},
 			headers: map[string]string{
 				"Foo":    "Bar",
-				"X-Test": "Bar",
+				"X-Test": "Old",
 			},
 			want: map[string]string{
 				"Foo":    "Bar",
@@ -147,9 +148,9 @@ func TestHeaderRules(t *testing.T) {
 			},
 		},
 		{
-			name: "[Join] Join two headers multiple value",
+			name: "[Set] Join two headers multiple value",
 			rule: plug.Rule{
-				Type:   "Join",
+				Type:   "Set",
 				Sep:    ",",
 				Header: "X-Test",
 				Values: []string{
@@ -164,7 +165,7 @@ func TestHeaderRules(t *testing.T) {
 			},
 			want: map[string]string{
 				"Foo":    "Bar",
-				"X-Test": "Bar,Tested,Compiled,Working",
+				"X-Test": "Tested,Compiled,Working",
 			},
 		},
 		{
@@ -239,9 +240,9 @@ func TestHeaderRules(t *testing.T) {
 			},
 		},
 		{
-			name: "[Join] Join two headers simple value",
+			name: "[Set] Join two headers simple value",
 			rule: plug.Rule{
-				Type:   "Join",
+				Type:   "Set",
 				Sep:    ",",
 				Header: "X-Test",
 				Values: []string{
@@ -257,13 +258,13 @@ func TestHeaderRules(t *testing.T) {
 			want: map[string]string{
 				"Foo":      "Bar",
 				"X-Source": "Tested",
-				"X-Test":   "Bar,Tested",
+				"X-Test":   "Tested",
 			},
 		},
 		{
-			name: "[Join] Join two headers multiple value",
+			name: "[Set] Join two headers multiple value",
 			rule: plug.Rule{
-				Type:   "Join",
+				Type:   "Set",
 				Sep:    ",",
 				Header: "X-Test",
 				Values: []string{
@@ -281,15 +282,15 @@ func TestHeaderRules(t *testing.T) {
 			},
 			want: map[string]string{
 				"Foo":        "Bar",
-				"X-Test":     "Bar,Tested,Compiled,Working",
+				"X-Test":     "Tested,Compiled,Working",
 				"X-Source-1": "Tested",
 				"X-Source-3": "Working",
 			},
 		},
 		{
-			name: "[Join] Join two headers multiple value with itself",
+			name: "[Set] Join two headers multiple value with itself",
 			rule: plug.Rule{
-				Type:   "Join",
+				Type:   "Set",
 				Sep:    ",",
 				Header: "X-Test",
 				Values: []string{
@@ -306,7 +307,7 @@ func TestHeaderRules(t *testing.T) {
 			},
 			want: map[string]string{
 				"Foo":    "Bar",
-				"X-Test": "test,second,test,third",
+				"X-Test": "second,test,third",
 			},
 		},
 	}

--- a/rules-htransformation.yaml
+++ b/rules-htransformation.yaml
@@ -56,3 +56,40 @@ http:
                 - 'Foo'
                 - 'Bar'
               Type: 'Join'
+            # Advanced use cases for fix of #14
+            - Rule:
+              Name: 'Header transformation to another header value'
+              Header: 'X-Traefik-*'
+              Value: '^X-custom'
+              ValueIsHeaderPrefix: "^"
+              Type: 'Rename'
+            - Rule:
+              Name: 'Header addition'
+              Header: 'X-Custom'
+              Value: '^X-Source'
+              ValueIsHeaderPrefix: "^"
+              Type: 'Set'
+            - Rule:
+              Name: 'Header addition'
+              Header: 'X-Custom-2'
+              Value: '^X-Source'
+              ValueIsHeaderPrefix: "^"
+              Type: 'Set'
+            - Rule:
+              Name: 'Header join'
+              Header: 'X-Custom-2'
+              Sep: ','
+              ValueIsHeaderPrefix: "^"
+              Values:
+                - '^X-Source-1'
+                - 'Foo'
+              Type: 'Join'
+            - Rule:
+              Name: 'Header join'
+              Header: 'X-Forwarded-For'
+              Sep: ','
+              ValueIsHeaderPrefix: "^"
+              Values:
+                - '^CF-Connecting-IP'
+                - '192.168.0.1'
+              Type: 'Join'

--- a/rules-htransformation.yaml
+++ b/rules-htransformation.yaml
@@ -61,25 +61,25 @@ http:
               Name: 'Header transformation to another header value'
               Header: 'X-Traefik-*'
               Value: '^X-custom'
-              ValueIsHeaderPrefix: "^"
+              HeaderPrefix: "^"
               Type: 'Rename'
             - Rule:
               Name: 'Header addition'
               Header: 'X-Custom'
               Value: '^X-Source'
-              ValueIsHeaderPrefix: "^"
+              HeaderPrefix: "^"
               Type: 'Set'
             - Rule:
               Name: 'Header addition'
               Header: 'X-Custom-2'
               Value: '^X-Source'
-              ValueIsHeaderPrefix: "^"
+              HeaderPrefix: "^"
               Type: 'Set'
             - Rule:
               Name: 'Header join'
               Header: 'X-Custom-2'
               Sep: ','
-              ValueIsHeaderPrefix: "^"
+              HeaderPrefix: "^"
               Values:
                 - '^X-Source-1'
                 - 'Foo'
@@ -88,7 +88,7 @@ http:
               Name: 'Header join'
               Header: 'X-Forwarded-For'
               Sep: ','
-              ValueIsHeaderPrefix: "^"
+              HeaderPrefix: "^"
               Values:
                 - '^CF-Connecting-IP'
                 - '192.168.0.1'


### PR DESCRIPTION
**Breaking changes**

Removes `Join` to favor `Set` to perform both duties.

Includes #19 (fix for #14) as well to refer to other headers, which enables `Set` to work like `Join`.

