### PR TITLE
fix: don't erase double headers with same name

### DIFF
--- a/pkg/handler/rewrite/rewrite.go
+++ b/pkg/handler/rewrite/rewrite.go
@@ -63,9 +63,9 @@ func Handle(rw http.ResponseWriter, req *http.Request, rule types.Rule) {
 			}
 
 			if rule.SetOnResponse {
-				rw.Header().Set(rule.Header, replacedHeaderValue)
+				rw.Header().Add(rule.Header, replacedHeaderValue)
 			} else {
-				req.Header.Set(headerName, replacedHeaderValue)
+				req.Header.Add(headerName, replacedHeaderValue)
 			}
 		}
 	}


### PR DESCRIPTION
Currently, when there is 2 headers having the same name on a `RewriteValueRule`, the use of `Header.Set` will erase the previous one.

eg:

```
 http whoami.localhost 'set-cookie: test_1=42' 'set-cookie: test_2=43'
HTTP/1.1 200 OK
Content-Length: 430
Content-Type: text/plain; charset=utf-8
Date: Tue, 20 Jun 2023 10:33:05 GMT

Name: whoami
Hostname: f48f5d1ec863
IP: 127.0.0.1
IP: 172.20.0.3
RemoteAddr: 172.20.0.2:44670
GET / HTTP/1.1
Host: whoami.localhost
User-Agent: HTTPie/3.2.1
Accept: */*
Accept-Encoding: gzip, deflate
Set-Cookie: test_2=43; Domain=.example.com
[...]
```
