### PR TITLE
feat: add handler interface that handlers must implement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,23 +4,9 @@ run:
 linters:
   enable-all: true
   disable:
-    - exhaustivestruct # deprecated
-    - interfacer # deprecated
-    - varcheck # deprecated
-    - nosnakecase # deprecated
-    - ifshort # deprecated
-    - maligned # deprecated
-    - deadcode # deprecated
-    - scopelint # deprecated
-    - structcheck # deprecated
-    - golint # deprecated
-    - rowserrcheck # deprecated
-    - sqlclosecheck # deprecated
-    - wastedassign # deprecated
+    - gomnd # deprecated
+    - execinquery # deprecated
     - varnamelen # useless
-    - paralleltest # false positive
-    - tparallel # false positive
-    - tagliatelle # Breaking: 'Rule' tag -> 'rule'
     - ireturn # Not relevant
 
 issues:
@@ -40,3 +26,8 @@ linters-settings:
         deny:
           - pkg: "github.com/instana/testify"
             desc: not allowed
+  tagliatelle:
+    case:
+      use-field-name: true
+      rules:
+        yaml: goPascal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - paralleltest # false positive
     - tparallel # false positive
     - tagliatelle # Breaking: 'Rule' tag -> 'rule'
+    - ireturn # Not relevant
 
 issues:
   exclude-rules:

--- a/htransformation_test.go
+++ b/htransformation_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name    string
 		config  *plug.Config
@@ -108,6 +110,8 @@ func TestValidation(t *testing.T) {
 }
 
 func TestHeaderRules(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name             string
 		rule             types.Rule

--- a/pkg/handler/deleter/delete.go
+++ b/pkg/handler/deleter/delete.go
@@ -7,16 +7,24 @@ import (
 	"github.com/tomMoulard/htransformation/pkg/utils/header"
 )
 
-func Validate(types.Rule) error {
+type Deleter struct {
+	rule *types.Rule
+}
+
+func New(rule types.Rule) (types.Handler, error) {
+	return &Deleter{rule: &rule}, nil
+}
+
+func (d *Deleter) Validate() error {
 	return nil
 }
 
-func Handle(rw http.ResponseWriter, req *http.Request, rule types.Rule) {
-	if rule.SetOnResponse {
-		rw.Header().Del(rule.Header)
+func (d *Deleter) Handle(rw http.ResponseWriter, req *http.Request) {
+	if d.rule.SetOnResponse {
+		rw.Header().Del(d.rule.Header)
 
 		return
 	}
 
-	header.Delete(req, rule.Header)
+	header.Delete(req, d.rule.Header)
 }

--- a/pkg/handler/deleter/delete_test.go
+++ b/pkg/handler/deleter/delete_test.go
@@ -146,6 +146,8 @@ func TestDeleteHandlerOnResponse(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name    string
 		rule    types.Rule

--- a/pkg/handler/deleter/delete_test.go
+++ b/pkg/handler/deleter/delete_test.go
@@ -70,7 +70,10 @@ func TestDeleteHandler(t *testing.T) {
 				req.Header.Add(hName, hVal)
 			}
 
-			deleter.Handle(nil, req, test.rule)
+			deleteHandler, err := deleter.New(test.rule)
+			require.NoError(t, err)
+
+			deleteHandler.Handle(nil, req)
 
 			for hName, hVal := range test.expectedHeaders {
 				assert.Equal(t, hVal, req.Header.Get(hName))
@@ -130,7 +133,10 @@ func TestDeleteHandlerOnResponse(t *testing.T) {
 				rw.Header().Add(hName, hVal)
 			}
 
-			deleter.Handle(rw, nil, test.rule)
+			deleteHandler, err := deleter.New(test.rule)
+			require.NoError(t, err)
+
+			deleteHandler.Handle(rw, nil)
 
 			for hName, hVal := range test.want {
 				assert.Equal(t, hVal, rw.Header().Get(hName))
@@ -163,7 +169,10 @@ func TestValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := deleter.Validate(test.rule)
+			deleteHandler, err := deleter.New(test.rule)
+			require.NoError(t, err)
+
+			err = deleteHandler.Validate()
 			t.Log(err)
 
 			if test.wantErr {

--- a/pkg/handler/join/join_test.go
+++ b/pkg/handler/join/join_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestJoinHandler(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		rule            types.Rule
@@ -215,6 +217,8 @@ func TestJoinHandler(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name    string
 		rule    types.Rule

--- a/pkg/handler/join/join_test.go
+++ b/pkg/handler/join/join_test.go
@@ -199,7 +199,10 @@ func TestJoinHandler(t *testing.T) {
 				req.Header.Add(hName, hVal)
 			}
 
-			join.Handle(nil, req, test.rule)
+			joinHandler, err := join.New(test.rule)
+			require.NoError(t, err)
+
+			joinHandler.Handle(nil, req)
 
 			for hName, hVal := range test.expectedHeaders {
 				assert.Equal(t, hVal, req.Header.Get(hName))
@@ -262,7 +265,10 @@ func TestValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := join.Validate(test.rule)
+			joinHandler, err := join.New(test.rule)
+			require.NoError(t, err)
+
+			err = joinHandler.Validate()
 			t.Log(err)
 
 			if test.wantErr {

--- a/pkg/handler/rename/rename_test.go
+++ b/pkg/handler/rename/rename_test.go
@@ -128,6 +128,8 @@ func TestRenameHandler(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		rule            types.Rule

--- a/pkg/handler/rewrite/rewrite_test.go
+++ b/pkg/handler/rewrite/rewrite_test.go
@@ -139,6 +139,8 @@ func TestRewriteHandler(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		rule            types.Rule

--- a/pkg/handler/set/set.go
+++ b/pkg/handler/set/set.go
@@ -7,20 +7,28 @@ import (
 	"github.com/tomMoulard/htransformation/pkg/utils/header"
 )
 
-func Validate(rule types.Rule) error {
-	if rule.Header == "" {
+type Set struct {
+	rule *types.Rule
+}
+
+func New(rule types.Rule) (types.Handler, error) {
+	return &Set{rule: &rule}, nil
+}
+
+func (s *Set) Validate() error {
+	if s.rule.Header == "" {
 		return types.ErrMissingRequiredFields
 	}
 
 	return nil
 }
 
-func Handle(rw http.ResponseWriter, req *http.Request, rule types.Rule) {
-	if rule.SetOnResponse {
-		rw.Header().Set(rule.Header, rule.Value)
+func (s *Set) Handle(rw http.ResponseWriter, req *http.Request) {
+	if s.rule.SetOnResponse {
+		rw.Header().Set(s.rule.Header, s.rule.Value)
 
 		return
 	}
 
-	header.Set(req, rule.Header, rule.Value)
+	header.Set(req, s.rule.Header, s.rule.Value)
 }

--- a/pkg/handler/set/set_test.go
+++ b/pkg/handler/set/set_test.go
@@ -94,8 +94,11 @@ func TestSetHandler(t *testing.T) {
 				req.Header.Add(hName, hVal)
 			}
 
+			setHandler, err := set.New(test.rule)
+			require.NoError(t, err)
+
 			rw := httptest.NewRecorder()
-			set.Handle(rw, req, test.rule)
+			setHandler.Handle(rw, req)
 
 			for hName, hVal := range test.wantOnRequest {
 				assert.Equal(t, hVal, req.Header.Get(hName))
@@ -142,7 +145,10 @@ func TestValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := set.Validate(test.rule)
+			setHandler, err := set.New(test.rule)
+			require.NoError(t, err)
+
+			err = setHandler.Validate()
 			t.Log(err)
 
 			if test.wantErr {

--- a/pkg/handler/set/set_test.go
+++ b/pkg/handler/set/set_test.go
@@ -115,6 +115,8 @@ func TestSetHandler(t *testing.T) {
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name    string
 		rule    types.Rule

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"net/http"
 	"regexp"
 )
 
@@ -41,3 +42,8 @@ var ErrMissingRequiredFields = errors.New("missing required fields")
 var ErrInvalidRuleType = errors.New("invalid rule type")
 
 var ErrInvalidRegexp = errors.New("invalid regexp")
+
+type Handler interface {
+	Validate() error
+	Handle(rw http.ResponseWriter, req *http.Request)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -34,7 +34,7 @@ type Rule struct {
 	ValueReplace string         `yaml:"ValueReplace"` // value used as replacement in rewrite
 	Values       []string       `yaml:"Values"`       // values to join
 	// if SetOnResponse is true, the header will be changed on the response. It will be on the request otherwise (default).
-	SetOnResponse bool `yaml:"SetOnRequest"`
+	SetOnResponse bool `yaml:"SetOnResponse"`
 }
 
 var ErrMissingRequiredFields = errors.New("missing required fields")


### PR DESCRIPTION
This PR enforce that handlers must implement the `Handler` interface for better consistency.

Please note that this PR also contains a small bug fix where the go YAML `structtag` for `SetOnResponse` was set to `SetOnRequest`.