### PR TITLE
fix rewrite header name when SetOnResponse = true

### DIFF
--- a/pkg/handler/rewrite/rewrite.go
+++ b/pkg/handler/rewrite/rewrite.go
@@ -81,7 +81,7 @@ func (r *Rewrite) Handle(rw http.ResponseWriter, req *http.Request) {
 		for _, headerValue := range headerValues {
 			replacedValue := r.replaceHeaderValue(headerValue)
 			if r.rule.SetOnResponse {
-				rw.Header().Add(r.rule.Header, replacedValue)
+				rw.Header().Add(headerName, replacedValue)
 			} else {
 				header.Add(req, headerName, replacedValue)
 			}


### PR DESCRIPTION
when `rule.SetOnResponse = true`, rewrite header name should be real header name, not `rule.Header` which could be regexp expression.