### PR TITLE
Fix rewrite header value spacing

### DIFF
--- a/pkg/handler/rewrite/rewrite.go
+++ b/pkg/handler/rewrite/rewrite.go
@@ -43,26 +43,20 @@ func (r *Rewrite) Validate() error {
 }
 
 func (r *Rewrite) replaceHeaderValue(headerValue string) string {
-	parts := strings.Split(headerValue, ";")
-	for i, part := range parts {
-		part = strings.TrimSpace(part)
-		parts[i] = r.ruleValueRegexp.ReplaceAllStringFunc(part, func(match string) string {
-			captures := r.ruleValueRegexp.FindStringSubmatch(match)
-			if len(captures) == 0 || captures[0] == "" {
-				return match
-			}
+	return r.ruleValueRegexp.ReplaceAllStringFunc(headerValue, func(match string) string {
+		captures := r.ruleValueRegexp.FindStringSubmatch(match)
+		if len(captures) == 0 || captures[0] == "" {
+			return match
+		}
 
-			replaced := r.rule.ValueReplace
+		replaced := r.rule.ValueReplace
 
-			for j, capture := range captures[1:] {
-				replaced = strings.ReplaceAll(replaced, fmt.Sprintf("$%d", j+1), capture)
-			}
+		for j, capture := range captures[1:] {
+			replaced = strings.ReplaceAll(replaced, fmt.Sprintf("$%d", j+1), capture)
+		}
 
-			return replaced
-		})
-	}
-
-	return strings.Join(parts, ";")
+		return replaced
+	})
 }
 
 func (r *Rewrite) Handle(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/handler/rewrite/rewrite_test.go
+++ b/pkg/handler/rewrite/rewrite_test.go
@@ -123,6 +123,21 @@ func TestRewriteHandler(t *testing.T) {
 			},
 			expectedHost: "example.com",
 		},
+		{
+			name: "multiple replacements with spaces",
+			rule: types.Rule{
+				Header:       "Foo",
+				Value:        "X-(\\d+)-(\\w+)",
+				ValueReplace: "Y-$2-$1",
+			},
+			requestHeaders: map[string]string{
+				"Foo": "X-12-Test; X-34-Prod",
+			},
+			expectedHeaders: map[string]string{
+				"Foo": "Y-Test-12; Y-Prod-34",
+			},
+			expectedHost: "example.com",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- preserve spacing when rewriting header values by processing the full header instead of trimming parts
- add regression test covering spaces in header value lists

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6879f583ca008322b5f82c8d0cfa33ca